### PR TITLE
Add support for proofs for non-exit communication

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -9,11 +9,12 @@ import { getLogIndex } from "./utils/logIndex";
 import { RequiredBlockMembers } from "./types";
 import { getCheckpointManager, getRootChainManager } from "./utils/contracts";
 import { hexToBuffer } from "./utils/buffer";
+import { EventSignature } from "./constants";
 
 export const calculateExitHash = async (
   maticChainProvider: JsonRpcProvider,
   burnTxHash: string,
-  logEventSigOrIndex: string,
+  logEventSig: EventSignature,
   selectedBurn = 0,
 ): Promise<string> => {
   const burnTxReceipt = await maticChainProvider.getTransactionReceipt(burnTxHash);
@@ -35,7 +36,7 @@ export const calculateExitHash = async (
     });
   const nibblesHex = hexConcat(nibbleArray);
 
-  const logIndex = getLogIndex(burnTxReceipt, logEventSigOrIndex, selectedBurn);
+  const logIndex = getLogIndex(burnTxReceipt, logEventSig, selectedBurn);
   const exitHash = solidityKeccak256(
     ["uint256", "bytes", "uint256"],
     [burnTxReceipt.blockNumber, nibblesHex, logIndex],
@@ -49,7 +50,7 @@ export const isBurnTxProcessed = async (
   maticChainProvider: JsonRpcProvider,
   rootChainContractAddress: string,
   burnTxHash: string,
-  logEventSig: string,
+  logEventSig: EventSignature,
 ): Promise<boolean> => {
   const exitHash = await calculateExitHash(maticChainProvider, burnTxHash, logEventSig);
   const rootChainContract = getRootChainManager(rootChainProvider, rootChainContractAddress);
@@ -88,7 +89,7 @@ export const isBurnTxClaimable = async (
   maticChainProvider: JsonRpcProvider,
   rootChainContractAddress: string,
   burnTxHash: string,
-  logEventSig: string,
+  logEventSig: EventSignature,
 ): Promise<boolean> => {
   const alreadyClaimed = await isBurnTxProcessed(
     rootChainProvider,

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -45,6 +45,14 @@ export const calculateExitHash = async (
   return exitHash;
 };
 
+/**
+ * Check whether a message has already been processed on root chain
+ * @param rootChainProvider - a Provider for the root chain (Ethereum)
+ * @param maticChainProvider - a JSONRpcProvider for the child chain (Matic)
+ * @param rootChainContractAddress - The address of the rootChainManager contract
+ * @param burnTxHash - The hash of the transaction of interest on the child chain
+ * @param logEventSig - The event signature for the log to check for
+ */
 export const isBurnTxProcessed = async (
   rootChainProvider: Provider,
   maticChainProvider: JsonRpcProvider,
@@ -59,6 +67,12 @@ export const isBurnTxProcessed = async (
   return exitProcessorContract.processedExits(exitHash);
 };
 
+/**
+ * Check whether a particular block on Matic has been checkpointed on the root chain
+ * @param rootChainProvider - a Provider for the root chain (Ethereum)
+ * @param rootChainContractAddress - The address of the rootChainManager contract
+ * @param blockNumber - The block number which we want to know the checkpoint status of
+ */
 export const isBlockCheckpointed = async (
   rootChainProvider: Provider,
   rootChainContractAddress: string,
@@ -70,6 +84,13 @@ export const isBlockCheckpointed = async (
   return BigNumber.from(lastChildBlock).gte(blockNumber);
 };
 
+/**
+ * Check whether a particular transaction has been checkpointed on the root chain
+ * @param rootChainProvider - a Provider for the root chain (Ethereum)
+ * @param maticChainProvider - a JSONRpcProvider for the child chain (Matic)
+ * @param rootChainContractAddress - The address of the rootChainManager contract
+ * @param burnTxHash - The hash of the transaction of interest on the child chain
+ */
 export const isBurnTxCheckpointed = async (
   rootChainProvider: Provider,
   maticChainProvider: JsonRpcProvider,
@@ -86,6 +107,15 @@ export const isBurnTxCheckpointed = async (
   return isBlockCheckpointed(rootChainProvider, rootChainContractAddress, burnTx.blockNumber);
 };
 
+/**
+ * Check whether an event log from a given transaction has been processed on the root chain
+ * @param rootChainProvider - a Provider for the root chain (Ethereum)
+ * @param maticChainProvider - a JSONRpcProvider for the child chain (Matic)
+ * @param rootChainContractAddress - The address of the rootChainManager contract
+ * @param burnTxHash - The hash of the transaction of interest on the child chain
+ * @param logEventSig - The event signature for the log to check for
+ * @param exitProcessorAddress - The address of the contract which tracks whether this exit has been processed
+ */
 export const isBurnTxClaimable = async (
   rootChainProvider: Provider,
   maticChainProvider: JsonRpcProvider,

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -48,13 +48,15 @@ export const calculateExitHash = async (
 export const isBurnTxProcessed = async (
   rootChainProvider: Provider,
   maticChainProvider: JsonRpcProvider,
-  rootChainContractAddress: string,
+  exitProcessorAddress: string,
   burnTxHash: string,
   logEventSig: EventSignature,
 ): Promise<boolean> => {
   const exitHash = await calculateExitHash(maticChainProvider, burnTxHash, logEventSig);
-  const rootChainContract = getRootChainManager(rootChainProvider, rootChainContractAddress);
-  return rootChainContract.processedExits(exitHash);
+  // We do a slight cheat here as the exitProcessor may not be a rootChainManager
+  // However we only need the processedExits function which the rootChainManager ABI has.
+  const exitProcessorContract = getRootChainManager(rootChainProvider, exitProcessorAddress);
+  return exitProcessorContract.processedExits(exitHash);
 };
 
 export const isBlockCheckpointed = async (
@@ -90,11 +92,12 @@ export const isBurnTxClaimable = async (
   rootChainContractAddress: string,
   burnTxHash: string,
   logEventSig: EventSignature,
+  exitProcessorAddress: string = rootChainContractAddress,
 ): Promise<boolean> => {
   const alreadyClaimed = await isBurnTxProcessed(
     rootChainProvider,
     maticChainProvider,
-    rootChainContractAddress,
+    exitProcessorAddress,
     burnTxHash,
     logEventSig,
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,10 @@ export enum EventSignature {
   ERC1155TransferBatch = "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb",
   SendMessage = "0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036",
 }
+
+// Need these to maintain interface
+export const ERC20_TRANSFER_EVENT_SIG = EventSignature.ERC20Transfer;
+export const ERC721_TRANSFER_EVENT_SIG = EventSignature.ERC721Transfer;
+export const ERC1155_TRANSFER_SINGLE_EVENT_SIG = EventSignature.ERC1155TransferSingle;
+export const ERC1155_TRANSFER_BATCH_EVENT_SIG = EventSignature.ERC1155TransferBatch;
+export const SEND_MESSAGE_EVENT_SIG = EventSignature.SendMessage;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+export enum EventSignature {
+  ERC20Transfer = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+  ERC721Transfer = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+  ERC1155TransferSingle = "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62",
+  ERC1155TransferBatch = "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb",
+  SendMessage = "0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036",
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,6 @@ export { buildReceiptProof, getReceiptBytes } from "./proofs/receiptProof";
 export { isBlockCheckpointed, isBurnTxCheckpointed, isBurnTxProcessed, isBurnTxClaimable } from "./checks";
 export * from "./constants";
 
-export const ERC20_TRANSFER_EVENT_SIG = EventSignature.ERC20Transfer;
-export const ERC721_TRANSFER_EVENT_SIG = EventSignature.ERC721Transfer;
-export const ERC1155_TRANSFER_SINGLE_EVENT_SIG = EventSignature.ERC1155TransferSingle;
-export const ERC1155_TRANSFER_BATCH_EVENT_SIG = EventSignature.ERC1155TransferBatch;
-export const SEND_MESSAGE_EVENT_SIG = EventSignature.SendMessage;
-
 export const encodePayload = ({
   headerBlockNumber,
   blockProof,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,18 @@ import { buildBlockProof } from "./proofs/blockProof";
 import { buildReceiptProof, getReceiptBytes } from "./proofs/receiptProof";
 import { getLogIndex } from "./utils/logIndex";
 import { hexToBuffer } from "./utils/buffer";
+import { EventSignature } from "./constants";
 
 export { buildBlockProof } from "./proofs/blockProof";
 export { buildReceiptProof, getReceiptBytes } from "./proofs/receiptProof";
 export { isBlockCheckpointed, isBurnTxCheckpointed, isBurnTxProcessed, isBurnTxClaimable } from "./checks";
+export * from "./constants";
 
-export const ERC20_TRANSFER_EVENT_SIG = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-export const ERC721_TRANSFER_EVENT_SIG = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-export const ERC1155_TRANSFER_SINGLE_EVENT_SIG = "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62";
-export const ERC1155_TRANSFER_BATCH_EVENT_SIG = "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb";
+export const ERC20_TRANSFER_EVENT_SIG = EventSignature.ERC20Transfer;
+export const ERC721_TRANSFER_EVENT_SIG = EventSignature.ERC721Transfer;
+export const ERC1155_TRANSFER_SINGLE_EVENT_SIG = EventSignature.ERC1155TransferSingle;
+export const ERC1155_TRANSFER_BATCH_EVENT_SIG = EventSignature.ERC1155TransferBatch;
+export const SEND_MESSAGE_EVENT_SIG = EventSignature.SendMessage;
 
 export const encodePayload = ({
   headerBlockNumber,
@@ -51,7 +54,7 @@ export const buildPayloadForExit = async (
   maticChainProvider: JsonRpcProvider,
   rootChainContractAddress: string,
   burnTxHash: string,
-  logEventSigOrIndex: string,
+  logEventSig: EventSignature,
   selectedBurn = 0,
 ): Promise<ExitProof> => {
   // Check that we can actually confirm that the burn transaction exists
@@ -64,7 +67,7 @@ export const buildPayloadForExit = async (
     throw new Error("Could not find blockHash of burnTx");
   }
 
-  const logIndex = getLogIndex(burnTxReceipt, logEventSigOrIndex, selectedBurn);
+  const logIndex = getLogIndex(burnTxReceipt, logEventSig, selectedBurn);
 
   // Build proof that the burn transaction is included in this block.
   const { receipt, parentNodes, path } = await buildReceiptProof(maticChainProvider, burnTxHash);

--- a/src/utils/logIndex.ts
+++ b/src/utils/logIndex.ts
@@ -32,16 +32,16 @@ export const getLogIndex = (
   selectedBurn = 0,
 ): number => {
   const predicate = predicateMap[logEventSig];
-  const burnIndices = transactionReceipt.logs.reduce((acc: number[], log, index) => {
+  const eventIndices = transactionReceipt.logs.reduce((acc: number[], log, index) => {
     if (predicate(log.topics)) {
       acc.push(index);
     }
     return acc;
   }, []);
 
-  if (burnIndices.length === 0) {
+  if (eventIndices.length === 0) {
     throw new Error("Burn log not found in receipt");
   }
 
-  return burnIndices[selectedBurn];
+  return eventIndices[selectedBurn];
 };

--- a/src/utils/logIndex.ts
+++ b/src/utils/logIndex.ts
@@ -1,5 +1,24 @@
 import { TransactionReceipt } from "@ethersproject/providers";
 import { HashZero } from "@ethersproject/constants";
+import { EventSignature } from "../constants";
+
+// Due to withdrawals sharing the Transfer event, we must add some extra checks to ignore non-burn transfers
+// This is required to be able to handle transactions which moves tokens and then burns them atomically
+const defaultPredicate = (expectedEventSig: string, topics: string[]) => topics[0].toLowerCase() === expectedEventSig;
+const erc20LikePredicate = (expectedEventSig: string, topics: string[]) =>
+  defaultPredicate(expectedEventSig, topics) && topics[2].toLowerCase() === HashZero;
+const erc1155LikePredicate = (expectedEventSig: string, topics: string[]) =>
+  defaultPredicate(expectedEventSig, topics) && topics[3].toLowerCase() === HashZero;
+
+const predicateMap: Record<EventSignature, (topics: string[]) => boolean> = {
+  [EventSignature.ERC20Transfer]: (topics: string[]) => erc20LikePredicate(EventSignature.ERC20Transfer, topics),
+  [EventSignature.ERC721Transfer]: (topics: string[]) => erc20LikePredicate(EventSignature.ERC721Transfer, topics),
+  [EventSignature.ERC1155TransferSingle]: (topics: string[]) =>
+    erc1155LikePredicate(EventSignature.ERC1155TransferSingle, topics),
+  [EventSignature.ERC1155TransferBatch]: (topics: string[]) =>
+    erc1155LikePredicate(EventSignature.ERC1155TransferBatch, topics),
+  [EventSignature.SendMessage]: (topics: string[]) => defaultPredicate(EventSignature.SendMessage, topics),
+};
 
 /**
  * Pulls the index of the first burn log from a transaction receipt.
@@ -7,11 +26,14 @@ import { HashZero } from "@ethersproject/constants";
  * @param logEventSig - The log which corresponds to the Transfer event for the asset type being burnt
  * @param selectedBurn - selects which burn we want to find the index for
  */
-export const getLogIndex = (transactionReceipt: TransactionReceipt, logEventSig: string, selectedBurn = 0): number => {
+export const getLogIndex = (
+  transactionReceipt: TransactionReceipt,
+  logEventSig: EventSignature,
+  selectedBurn = 0,
+): number => {
+  const predicate = predicateMap[logEventSig];
   const burnIndices = transactionReceipt.logs.reduce((acc: number[], log, index) => {
-    // Check topics[0] to find a transfer of the correct asset type e.g. ERC20
-    // Check topics[2] to filter out any transfers previous to the burn i.e. those not to the zero address
-    if (log.topics[0].toLowerCase() === logEventSig.toLowerCase() && log.topics[2].toLowerCase() === HashZero) {
+    if (predicate(log.topics)) {
       acc.push(index);
     }
     return acc;

--- a/test/integration/dataFetching/calculateExitHash.ts
+++ b/test/integration/dataFetching/calculateExitHash.ts
@@ -1,6 +1,6 @@
 /* eslint-disable func-names */
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { ERC20_TRANSFER_EVENT_SIG } from "../../../src";
+import { EventSignature } from "../../../src";
 import { calculateExitHash } from "../../../src/checks";
 import chai from "../../chai-setup";
 
@@ -30,7 +30,7 @@ export function testCalculateExitHash(): void {
     it(`should return ${expectedExitHash} as exit hash for burn hash ${burnHash}`, async () => {
       const provider = new JsonRpcProvider("https://rpc-mainnet.matic.network");
 
-      const exitHash = await calculateExitHash(provider, burnHash, ERC20_TRANSFER_EVENT_SIG);
+      const exitHash = await calculateExitHash(provider, burnHash, EventSignature.ERC20Transfer);
 
       expect(exitHash).to.eq(expectedExitHash);
     });

--- a/test/integration/proofs/full-proof.ts
+++ b/test/integration/proofs/full-proof.ts
@@ -4,7 +4,7 @@ import { deployments, ethers } from "hardhat";
 
 import { JsonRpcProvider } from "@ethersproject/providers";
 import chai from "../../chai-setup";
-import { buildPayloadForExit, encodePayload, ERC20_TRANSFER_EVENT_SIG } from "../../../src";
+import { buildPayloadForExit, encodePayload, EventSignature } from "../../../src";
 import { getCheckpointManager } from "../../../src/utils/contracts";
 
 const { expect } = chai;
@@ -38,7 +38,7 @@ export function testFullProof(): void {
         maticProvider,
         rootChainManagerProxy,
         burnHash,
-        ERC20_TRANSFER_EVENT_SIG,
+        EventSignature.ERC20Transfer,
       );
 
       // Pull checkpoint from mainnet and insert it onto local chain

--- a/test/proofs/offchain/full-proof.ts
+++ b/test/proofs/offchain/full-proof.ts
@@ -1,5 +1,5 @@
 /* eslint-disable func-names */
-import { encodePayload, ERC20_TRANSFER_EVENT_SIG } from "../../../src";
+import { encodePayload, EventSignature } from "../../../src";
 import { buildMerkleProof } from "../../../src/proofs/blockProof";
 import { buildMerklePatriciaProof } from "../../../src/proofs/receiptProof";
 import { ExitProof } from "../../../src/types";
@@ -16,7 +16,7 @@ export function testFullProof(): void {
   it("should generate a valid proof", async () => {
     const receiptProof = await buildMerklePatriciaProof(receipt, receipts, block.number, block.hash);
     const blockProof = await buildMerkleProof(block, blocks, CHECKPOINT_ID);
-    const logIndex = getLogIndex(receipt, ERC20_TRANSFER_EVENT_SIG);
+    const logIndex = getLogIndex(receipt, EventSignature.ERC20Transfer);
 
     const exitProof: ExitProof = {
       headerBlockNumber: CHECKPOINT_ID.toNumber(),

--- a/test/proofs/onchain/full-proof.ts
+++ b/test/proofs/onchain/full-proof.ts
@@ -2,7 +2,7 @@
 import { Contract } from "@ethersproject/contracts";
 import { deployments, ethers } from "hardhat";
 
-import { encodePayload, ERC20_TRANSFER_EVENT_SIG } from "../../../src";
+import { encodePayload, EventSignature } from "../../../src";
 import { buildMerkleProof } from "../../../src/proofs/blockProof";
 import { buildMerklePatriciaProof } from "../../../src/proofs/receiptProof";
 import { ExitProof } from "../../../src/types";
@@ -24,7 +24,7 @@ export function testFullProof(): void {
   it("should generate a valid proof", async () => {
     const receiptProof = await buildMerklePatriciaProof(receipt, receipts, block.number, block.hash);
     const blockProof = await buildMerkleProof(block, blocks, CHECKPOINT_ID);
-    const logIndex = getLogIndex(receipt, ERC20_TRANSFER_EVENT_SIG);
+    const logIndex = getLogIndex(receipt, EventSignature.ERC20Transfer);
 
     const exitProof: ExitProof = {
       headerBlockNumber: CHECKPOINT_ID.toNumber(),


### PR DESCRIPTION
This PR adds support for proving the existence of logs for the `MessageSent` event allowing more general L1<->L2 communication See: https://github.com/maticnetwork/pos-portal/blob/master/contracts/tunnel/BaseRootTunnel.sol